### PR TITLE
Api video select bugfix

### DIFF
--- a/client/src/components/VideoPage.js
+++ b/client/src/components/VideoPage.js
@@ -165,9 +165,14 @@ class VideoPage extends Component{
               self.askForClip();
           }
           else if (this.readyState === XMLHttpRequest.DONE) {
-            alert("post failed, try again later when you are logged in or something.");
+            self.setState({
+              videoChosen: false,
+              video: null,
+              LabelIndex: -1
+            });
+            self.askForClip();
+            console.log("Asking for clip after something went wrong");
           }
-
       }
 
       // brings the user from the props

--- a/client/src/components/VideoPlayer.js
+++ b/client/src/components/VideoPlayer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactPlayer from "react-player";
-import {LoadingMessage,LoadingIcon,Button} from 'lucid-ui';
+import {LoadingMessage,LoadingIcon} from 'lucid-ui';
 
 
 class VideoPlayer extends React.Component {


### PR DESCRIPTION
Previously, it was possible for videos to exceed their maximum number of votes (ie to generate extraneous data) if multiple users simultaneously using the site requested the video. This was because the system was only checking the votes already stored in the database and not counting the users who currently had a video "checked out" without yet voting on it.

This fix introduces a system by which videos are tracked so that the number of checkouts does not exceed the number of votes necessary to reach the vote maximum. A time out of 10 minutes safe guards the checkout system and protects the integrity of the list should users leave or refresh the site while a video is checked out.

Videos past their due date are automatically removed when a user requests a new video or votes on an existing video. 

If the user votes on a video past its due date, he is none the wiser. Unfortunately it does mean he may see the video again and become confused. We may consider speaking with Xandr to discuss what the appropriate UX should be: inform the user vs don't inform the user.