### PR TITLE
UX improvment and bug fix related to video submit

### DIFF
--- a/client/src/components/VideoPage.js
+++ b/client/src/components/VideoPage.js
@@ -110,11 +110,8 @@ class VideoPage extends Component{
 
         </RadioGroup>
 
-        <Button id="submit-label-button" isDisabled={this.state.LabelIndex===-1}
-          onClick={()=>{
-            this.submitLabel();
-            this.askForClip();
-          }} size="large">
+        <Button id="submit-label-button" onClick={this.submitLabel}
+          isDisabled={this.state.LabelIndex===-1} size="large">
             <CheckIcon />Save and Continue
         </Button>
         <Button id="submit-label-button" isDisabled={this.state.LabelIndex===-1}
@@ -243,6 +240,8 @@ class VideoPage extends Component{
               numSessionVoteCount++;
               self.setState({sessionVoteCount:numSessionVoteCount})
               sessionStorage.setItem("sessionVoteCount", numSessionVoteCount);
+
+              self.askForClip();
           }
           else if (this.readyState === XMLHttpRequest.DONE) {
             self.setState({
@@ -250,6 +249,7 @@ class VideoPage extends Component{
               video: null,
               LabelIndex: -1
             });
+            self.askForClip();
           }
       }
 

--- a/client/src/components/VideoPage.js
+++ b/client/src/components/VideoPage.js
@@ -110,8 +110,11 @@ class VideoPage extends Component{
 
         </RadioGroup>
 
-        <Button id="submit-label-button" onClick={this.submitLabel}
-          isDisabled={this.state.LabelIndex===-1} size="large">
+        <Button id="submit-label-button" isDisabled={this.state.LabelIndex===-1}
+          onClick={()=>{
+            this.submitLabel();
+            this.askForClip();
+          }} size="large">
             <CheckIcon />Save and Continue
         </Button>
         <Button id="submit-label-button" isDisabled={this.state.LabelIndex===-1}
@@ -240,8 +243,6 @@ class VideoPage extends Component{
               numSessionVoteCount++;
               self.setState({sessionVoteCount:numSessionVoteCount})
               sessionStorage.setItem("sessionVoteCount", numSessionVoteCount);
-
-              self.askForClip();
           }
           else if (this.readyState === XMLHttpRequest.DONE) {
             self.setState({
@@ -249,7 +250,6 @@ class VideoPage extends Component{
               video: null,
               LabelIndex: -1
             });
-            self.askForClip();
           }
       }
 


### PR DESCRIPTION
TL;DR in bold.

**Overdue videos are now submitted by the API if they need votes. This prevents users from seeing the same video twice.** It should be noted that there is an edge case here: if user 1 requests a video and allows it to time out, user 2 requests a video and receives the same one, then user 1 submits, user 2's submission might not count when in fact it should and user 1's submission should not. This is okay from the developer's perspective: we needed one submission and received one submission. From the user's perspective, when their vote doesn't count their "Votes this session" will not increment, and if they are paying close attention they might notice and if they notice they might become frustrated. I personally think its too rare and too niche; the number of users that will be frustrated and the degree of their frustration is so low that it isn't worth the effort to fix. (fixing would likely entail implementation of a checkout-key system to ensure the user with the checkout is the same user that sent the submission request).

**Also changed the submit buttons in the UI.** Now, the "submitLabel" function only submits the label and the "askForClip" function is the only way to ask for a clip. The "Submit and Continue" button submits the label and asks for a clip, whereas the "Save and Exit" button only submits the label before exiting. **This prevents users who "Save and Exit" from checking out videos before they leave and keeps the API library cleaner.** It should be noted that the video remains checked out if the user 1) exits 2) refreshes or 3) logs out; therefore, it is still necessary to have the time out in the API.